### PR TITLE
register function

### DIFF
--- a/auto-farm/src/common_storage.rs
+++ b/auto-farm/src/common_storage.rs
@@ -1,4 +1,4 @@
-use crate::address_to_id_mapper::{AddressId, AddressToIdMapper, NULL_ID};
+use crate::address_to_id_mapper::AddressToIdMapper;
 
 elrond_wasm::imports!();
 
@@ -13,10 +13,6 @@ pub trait CommonStorageModule {
             caller == proxy_claim_address,
             "Only the proxy can claim in user's place"
         );
-    }
-
-    fn require_valid_id(&self, id: AddressId) {
-        require!(id != NULL_ID, "Unknown user");
     }
 
     #[storage_mapper("userIds")]

--- a/auto-farm/src/farm_actions.rs
+++ b/auto-farm/src/farm_actions.rs
@@ -6,7 +6,7 @@ use crate::{farm_external_storage_read::State, user_rewards::UniquePayments};
 elrond_wasm::imports!();
 
 #[elrond_wasm::module]
-pub trait UserFarmActionsModule:
+pub trait FarmActionsModule:
     crate::common_storage::CommonStorageModule
     + crate::farms_whitelist::FarmsWhitelistModule
     + crate::farm_external_storage_read::FarmExternalStorageReadModule
@@ -25,8 +25,7 @@ pub trait UserFarmActionsModule:
         self.require_caller_proxy_claim_address();
 
         let farms_mapper = self.farm_ids();
-        let user_id = self.user_ids().get_id(&user);
-        self.require_valid_id(user_id);
+        let user_id = self.user_ids().get_id_non_zero(&user);
 
         let locked_token_id = self.get_locked_token_id();
         let user_tokens_mapper = self.user_farm_tokens(user_id);

--- a/auto-farm/src/farms_whitelist.rs
+++ b/auto-farm/src/farms_whitelist.rs
@@ -18,7 +18,7 @@ pub trait FarmsWhitelistModule:
                 continue;
             }
 
-            let new_id = farms_mapper.get_id_or_insert(&farm_addr);
+            let new_id = farms_mapper.insert_new(&farm_addr);
             let farm_config = self.get_farm_config(&farm_addr);
             self.farm_for_farm_token(&farm_config.farm_token_id)
                 .set(new_id);

--- a/auto-farm/src/fees_collector_actions.rs
+++ b/auto-farm/src/fees_collector_actions.rs
@@ -19,6 +19,7 @@ pub trait FeesCollectorActionsModule:
     fn claim_fees_collector_rewards(&self, user: ManagedAddress) {
         self.require_caller_proxy_claim_address();
 
+        let user_id = self.user_ids().get_id_non_zero(&user);
         let mut rewards = self.call_fees_collector_claim(user.clone());
         let rewards_len = rewards.len();
         if rewards_len == 0 {
@@ -35,7 +36,6 @@ pub trait FeesCollectorActionsModule:
         }
 
         let merged_rewards = UniquePayments::new_from_payments(rewards);
-        let user_id = self.user_ids().get_id_or_insert(&user);
         self.add_user_rewards(user, user_id, locked_tokens, merged_rewards);
     }
 

--- a/auto-farm/src/lib.rs
+++ b/auto-farm/src/lib.rs
@@ -11,6 +11,7 @@ pub mod fees;
 pub mod fees_collector_actions;
 pub mod locked_token_merging;
 pub mod metabonding_actions;
+pub mod registration;
 pub mod user_farm_tokens;
 pub mod user_rewards;
 
@@ -21,6 +22,7 @@ pub trait AutoFarm:
     farms_whitelist::FarmsWhitelistModule
     + farm_external_storage_read::FarmExternalStorageReadModule
     + common_storage::CommonStorageModule
+    + registration::RegistrationModule
     + user_farm_tokens::UserFarmTokensModule
     + farm_actions::FarmActionsModule
     + metabonding_actions::MetabondingActionsModule
@@ -74,11 +76,5 @@ pub trait AutoFarm:
             self.deduct_energy_from_sender(old_claim_address, &tokens_vec);
             self.add_energy_to_destination(new_proxy_claim_address, &tokens_vec);
         }
-    }
-
-    #[endpoint]
-    fn register(&self) {
-        let caller = self.blockchain().get_caller();
-        let _ = self.user_ids().insert_new(&caller);
     }
 }

--- a/auto-farm/src/lib.rs
+++ b/auto-farm/src/lib.rs
@@ -4,13 +4,13 @@ elrond_wasm::imports!();
 
 pub mod address_to_id_mapper;
 pub mod common_storage;
+pub mod farm_actions;
 pub mod farm_external_storage_read;
 pub mod farms_whitelist;
 pub mod fees;
 pub mod fees_collector_actions;
 pub mod locked_token_merging;
 pub mod metabonding_actions;
-pub mod user_farm_actions;
 pub mod user_farm_tokens;
 pub mod user_rewards;
 
@@ -22,7 +22,7 @@ pub trait AutoFarm:
     + farm_external_storage_read::FarmExternalStorageReadModule
     + common_storage::CommonStorageModule
     + user_farm_tokens::UserFarmTokensModule
-    + user_farm_actions::UserFarmActionsModule
+    + farm_actions::FarmActionsModule
     + metabonding_actions::MetabondingActionsModule
     + fees_collector_actions::FeesCollectorActionsModule
     + user_rewards::UserRewardsModule
@@ -74,5 +74,11 @@ pub trait AutoFarm:
             self.deduct_energy_from_sender(old_claim_address, &tokens_vec);
             self.add_energy_to_destination(new_proxy_claim_address, &tokens_vec);
         }
+    }
+
+    #[endpoint]
+    fn register(&self) {
+        let caller = self.blockchain().get_caller();
+        let _ = self.user_ids().insert_new(&caller);
     }
 }

--- a/auto-farm/src/metabonding_actions.rs
+++ b/auto-farm/src/metabonding_actions.rs
@@ -24,13 +24,13 @@ pub trait MetabondingActionsModule:
     ) {
         self.require_caller_proxy_claim_address();
 
+        let user_id = self.user_ids().get_id_non_zero(&user);
         let rewards = self.call_metabonding_claim(user.clone(), claim_args);
         if rewards.is_empty() {
             return;
         }
 
         let merged_rewards = UniquePayments::new_from_payments(rewards);
-        let user_id = self.user_ids().get_id_or_insert(&user);
         self.add_user_rewards(user, user_id, UniquePayments::new(), merged_rewards);
     }
 

--- a/auto-farm/src/registration.rs
+++ b/auto-farm/src/registration.rs
@@ -32,9 +32,8 @@ pub trait RegistrationModule:
         let claimed_rewards = self.user_claim_rewards(caller, user_id);
         let _ = ids_mapper.remove_by_id(user_id);
 
-        let mut results = ManagedVec::new();
+        let mut results = farm_tokens;
         results.append_vec(claimed_rewards);
-        results.append_vec(farm_tokens);
 
         results
     }

--- a/auto-farm/src/registration.rs
+++ b/auto-farm/src/registration.rs
@@ -1,0 +1,41 @@
+use common_structs::PaymentsVec;
+
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait RegistrationModule:
+    crate::common_storage::CommonStorageModule
+    + crate::user_rewards::UserRewardsModule
+    + crate::fees::FeesModule
+    + crate::locked_token_merging::LockedTokenMergingModule
+    + crate::farms_whitelist::FarmsWhitelistModule
+    + crate::farm_external_storage_read::FarmExternalStorageReadModule
+    + crate::user_farm_tokens::UserFarmTokensModule
+    + lkmex_transfer::energy_transfer::EnergyTransferModule
+    + legacy_token_decode_module::LegacyTokenDecodeModule
+    + energy_query::EnergyQueryModule
+    + utils::UtilsModule
+{
+    #[endpoint]
+    fn register(&self) {
+        let caller = self.blockchain().get_caller();
+        let _ = self.user_ids().insert_new(&caller);
+    }
+
+    #[endpoint(withdrawAllAndUnregister)]
+    fn withdraw_all_and_unregister(&self) -> PaymentsVec<Self::Api> {
+        let caller = self.blockchain().get_caller();
+        let ids_mapper = self.user_ids();
+        let user_id = ids_mapper.get_id_non_zero(&caller);
+
+        let farm_tokens = self.withdraw_farm_tokens(&caller, user_id);
+        let claimed_rewards = self.user_claim_rewards(caller, user_id);
+        let _ = ids_mapper.remove_by_id(user_id);
+
+        let mut results = ManagedVec::new();
+        results.append_vec(claimed_rewards);
+        results.append_vec(farm_tokens);
+
+        results
+    }
+}

--- a/auto-farm/src/user_farm_tokens.rs
+++ b/auto-farm/src/user_farm_tokens.rs
@@ -29,13 +29,20 @@ pub trait UserFarmTokensModule:
     }
 
     #[endpoint(withdrawFarmTokens)]
-    fn withdraw_farm_tokens(&self) -> PaymentsVec<Self::Api> {
+    fn withdraw_farm_tokens_endpoint(&self) -> PaymentsVec<Self::Api> {
         let caller = self.blockchain().get_caller();
         let user_id = self.user_ids().get_id_non_zero(&caller);
+        self.withdraw_farm_tokens(&caller, user_id)
+    }
 
+    fn withdraw_farm_tokens(
+        &self,
+        user: &ManagedAddress,
+        user_id: AddressId,
+    ) -> PaymentsVec<Self::Api> {
         let tokens = self.user_farm_tokens(user_id).take();
         if !tokens.is_empty() {
-            self.send().direct_multi(&caller, &tokens);
+            self.send().direct_multi(user, &tokens);
         }
 
         tokens

--- a/auto-farm/src/user_farm_tokens.rs
+++ b/auto-farm/src/user_farm_tokens.rs
@@ -31,8 +31,7 @@ pub trait UserFarmTokensModule:
     #[endpoint(withdrawFarmTokens)]
     fn withdraw_farm_tokens(&self) -> PaymentsVec<Self::Api> {
         let caller = self.blockchain().get_caller();
-        let user_id = self.user_ids().get_id(&caller);
-        self.require_valid_id(user_id);
+        let user_id = self.user_ids().get_id_non_zero(&caller);
 
         let tokens = self.user_farm_tokens(user_id).take();
         if !tokens.is_empty() {

--- a/auto-farm/src/user_rewards.rs
+++ b/auto-farm/src/user_rewards.rs
@@ -135,8 +135,7 @@ pub trait UserRewardsModule:
     #[endpoint(userClaimRewards)]
     fn user_claim_rewards(&self) -> PaymentsVec<Self::Api> {
         let caller = self.blockchain().get_caller();
-        let user_id = self.user_ids().get_id(&caller);
-        self.require_valid_id(user_id);
+        let user_id = self.user_ids().get_id_non_zero(&caller);
 
         let rewards_mapper = self.user_rewards(user_id);
         self.claim_common(caller, rewards_mapper)

--- a/auto-farm/src/user_rewards.rs
+++ b/auto-farm/src/user_rewards.rs
@@ -133,12 +133,19 @@ pub trait UserRewardsModule:
     + utils::UtilsModule
 {
     #[endpoint(userClaimRewards)]
-    fn user_claim_rewards(&self) -> PaymentsVec<Self::Api> {
+    fn user_claim_rewards_endpoint(&self) -> PaymentsVec<Self::Api> {
         let caller = self.blockchain().get_caller();
         let user_id = self.user_ids().get_id_non_zero(&caller);
+        self.user_claim_rewards(caller, user_id)
+    }
 
+    fn user_claim_rewards(
+        &self,
+        user: ManagedAddress,
+        user_id: AddressId,
+    ) -> PaymentsVec<Self::Api> {
         let rewards_mapper = self.user_rewards(user_id);
-        self.claim_common(caller, rewards_mapper)
+        self.claim_common(user, rewards_mapper)
     }
 
     #[view(getUserRewards)]

--- a/auto-farm/tests/farm_claim_test.rs
+++ b/auto-farm/tests/farm_claim_test.rs
@@ -11,8 +11,8 @@ use energy_query::Energy;
 use sc_whitelist_module::SCWhitelistModule;
 use simple_lock::locked_token::LockedTokenAttributes;
 
+use auto_farm::farm_actions::FarmActionsModule;
 use auto_farm::fees::FeesModule;
-use auto_farm::user_farm_actions::UserFarmActionsModule;
 use auto_farm::user_farm_tokens::UserFarmTokensModule;
 use auto_farm::user_rewards::{UniquePayments, UserRewardsModule};
 use auto_farm::AutoFarm;

--- a/auto-farm/tests/metabonding_setup/mod.rs
+++ b/auto-farm/tests/metabonding_setup/mod.rs
@@ -54,11 +54,7 @@ where
     b_mock
         .execute_tx(&owner_addr, &mb_wrapper, &rust_zero, |sc| {
             let signer_addr = managed_address!(&Address::from(&SIGNER_ADDRESS));
-            sc.init(
-                signer_addr.clone(),
-                OptionalValue::None,
-                OptionalValue::None,
-            );
+            sc.init(signer_addr, OptionalValue::None, OptionalValue::None);
         })
         .assert_ok();
 

--- a/auto-farm/tests/other_scs_claim_test.rs
+++ b/auto-farm/tests/other_scs_claim_test.rs
@@ -6,6 +6,7 @@ use crate::{
     farm_with_locked_rewards_setup::FarmSetup,
     fees_collector_setup::{FIRST_TOKEN_ID, LOCKED_TOKEN_ID, SECOND_TOKEN_ID},
 };
+use auto_farm::registration::RegistrationModule;
 use auto_farm::{
     common_storage::MAX_PERCENTAGE,
     fees::FeesModule,

--- a/auto-farm/tests/other_scs_claim_test.rs
+++ b/auto-farm/tests/other_scs_claim_test.rs
@@ -80,6 +80,12 @@ fn metabonding_claim_through_auto_farm_test() {
 
     let first_user_addr = farm_setup.first_user.clone();
     b_mock
+        .execute_tx(&first_user_addr, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+        })
+        .assert_ok();
+
+    b_mock
         .execute_tx(&proxy_address, &auto_farm_wrapper, &rust_zero, |sc| {
             let mut claim_args = MultiValueEncoded::new();
             claim_args.push(
@@ -241,6 +247,20 @@ fn fees_collector_claim_through_auto_farm_test() {
 
     let first_user_addr = farm_setup.first_user.clone();
     let second_user_addr = farm_setup.second_user.clone();
+
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user_addr, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+        })
+        .assert_ok();
+
+    farm_setup
+        .b_mock
+        .execute_tx(&second_user_addr, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+        })
+        .assert_ok();
 
     farm_setup.set_user_energy(&first_user_addr, 1_000, 5, 500);
     farm_setup.set_user_energy(&second_user_addr, 9_000, 5, 500);

--- a/auto-farm/tests/register_test.rs
+++ b/auto-farm/tests/register_test.rs
@@ -1,0 +1,86 @@
+use auto_farm::{common_storage::CommonStorageModule, registration::RegistrationModule, AutoFarm};
+use elrond_wasm_debug::{managed_address, rust_biguint};
+use farm_with_locked_rewards_setup::FarmSetup;
+
+pub mod farm_with_locked_rewards_setup;
+
+const FEE_PERCENTAGE: u64 = 1_000; // 10%
+
+#[test]
+fn register_test() {
+    let rust_zero = rust_biguint!(0);
+    let mut farm_setup = FarmSetup::new(
+        farm_with_locked_rewards::contract_obj,
+        energy_factory::contract_obj,
+    );
+
+    let first_user = farm_setup.first_user.clone();
+    let energy_factory_addr = farm_setup.energy_factory_wrapper.address_ref().clone();
+
+    let proxy_address = farm_setup.b_mock.create_user_account(&rust_zero);
+    let auto_farm_wrapper = farm_setup.b_mock.create_sc_account(
+        &rust_zero,
+        Some(&farm_setup.owner),
+        auto_farm::contract_obj,
+        "auto farm",
+    );
+
+    farm_setup
+        .b_mock
+        .execute_tx(&farm_setup.owner, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.init(
+                managed_address!(&proxy_address),
+                FEE_PERCENTAGE,
+                managed_address!(&energy_factory_addr),
+                managed_address!(&energy_factory_addr), // unused here
+                managed_address!(&energy_factory_addr), // unused here
+            );
+        })
+        .assert_ok();
+
+    // register ok
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+
+            assert_eq!(sc.user_ids().get_id(&managed_address!(&first_user)), 1);
+        })
+        .assert_ok();
+
+    // try register again
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+        })
+        .assert_user_error("User already registered");
+
+    // unregister
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user, &auto_farm_wrapper, &rust_zero, |sc| {
+            let _ = sc.withdraw_all_and_unregister();
+
+            assert_eq!(sc.user_ids().get_id(&managed_address!(&first_user)), 0);
+        })
+        .assert_ok();
+
+    // try unregister again
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user, &auto_farm_wrapper, &rust_zero, |sc| {
+            let _ = sc.withdraw_all_and_unregister();
+        })
+        .assert_user_error("Unknown user");
+
+    // register again - ok
+    farm_setup
+        .b_mock
+        .execute_tx(&first_user, &auto_farm_wrapper, &rust_zero, |sc| {
+            sc.register();
+
+            assert_eq!(sc.user_ids().get_id(&managed_address!(&first_user)), 2);
+        })
+        .assert_ok();
+}

--- a/auto-farm/wasm/src/lib.rs
+++ b/auto-farm/wasm/src/lib.rs
@@ -5,9 +5,9 @@
 ////////////////////////////////////////////////////
 
 // Init:                                 1
-// Endpoints:                           19
+// Endpoints:                           21
 // Async Callback (empty):               1
-// Total number of exported functions:  21
+// Total number of exported functions:  23
 
 #![no_std]
 
@@ -20,6 +20,8 @@ elrond_wasm_node::wasm_endpoints! {
         getFarmForFarmToken
         getFarmsForFarmingToken
         getFarmConfig
+        register
+        withdrawAllAndUnregister
         depositFarmTokens
         withdrawFarmTokens
         getUserFarmTokens


### PR DESCRIPTION
- add a register function for users. Proxy can no longer claim for users that didn't either manually register or deposited farm tokens
- add an unregister function, which also withdraws all tokens in the process
- added some more utility functions for AddressToIdMapper
- renamed `user_farm_actions` to `farm_actions` for consistency